### PR TITLE
Add key combination to exit the screen and mpfshell programs

### DIFF
--- a/docs/firmware-and-testing.rst
+++ b/docs/firmware-and-testing.rst
@@ -108,8 +108,8 @@ try a baud rate of 9600. Do not be worried at this point if you only see garbage
 we are going to rewrite the firmware anyway. As long as you saw the tty device,
 you should be OK.
 
-Now, unplug your USB cable and run the ``reset`` command in your terminal
-session. You are ready to install the firmware.
+Now, exit ``screen`` (pressing Control-A k and then "y"), and run the ``reset``
+command in your terminal session. You are ready to install the firmware.
 
 Installing the Firmware and Testing the REPL
 --------------------------------------------

--- a/docs/mqtt.rst
+++ b/docs/mqtt.rst
@@ -230,7 +230,8 @@ You will definitely need to change the values for ``WIFI_ESSID``,
 ``WIFI_PASSWORD``, and ``MQTT_HOST``. The others can be left as-is.
 
 Now, use ``mpfshell`` to copy ``config.py`` and ``client.py`` to your
-ESP8266 (substituting for TTYDEVICE)::
+ESP8266 (substituting for TTYDEVICE or use Control-] to exit the repl
+if ``mpfshell`` is already running)::
 
   open TTYDEVICE
   put config.py


### PR DESCRIPTION
This probed tricky in previous hackathons as the same ``screen`` program uses a slightly different key combination on different platforms.