### PR TITLE
Add ThingFlow CircuitPlayground Express demo with adc sensor client

### DIFF
--- a/example_code/client_adc.py
+++ b/example_code/client_adc.py
@@ -1,0 +1,25 @@
+# Main program for ESP8266 to sample a potentiometer sensor and send sensor
+# events to an MQTT broker.
+
+# Configuration is stored in a separate config.py
+from config import SENSOR_ID, WIFI_ESSID, WIFI_PASSWORD, MQTT_HOST,\
+                   MQTT_TOPIC, SLEEP_TIME
+
+from wifi import wifi_connect, disable_wifi_ap
+from thingflow import *
+from adc_esp8266 import ADCSensor
+from mqtt_writer import MQTTWriter
+
+# setup network
+disable_wifi_ap()
+wifi_connect(WIFI_ESSID, WIFI_PASSWORD)
+
+# create objects
+m =  MQTTWriter(SENSOR_ID, MQTT_HOST, 1883, MQTT_TOPIC)
+sensor = ADCSensor(SENSOR_ID, min_rd=4, max_rd=1024)
+sched = Scheduler()
+
+# schedule and run
+sched.schedule_sensor(sensor, SLEEP_TIME, m)
+print("Running main loop with sample every %s seconds..." % SLEEP_TIME)
+sched.run_forever()

--- a/example_code/cpx_demo/README.rst
+++ b/example_code/cpx_demo/README.rst
@@ -1,0 +1,21 @@
+==============================================
+ThingFlow CircuitPlayground Express (CPX) demo
+==============================================
+This directory contains example code to drive a CircuitPlayground Express
+neopixel ring with wireless data.
+
+The setup involves a ESP8266 that captures an analog signal from a
+potentiometer and transmits it wirelessly using an MQTTWriter. Then the host
+computer decodes the wireless MQTTReader data and bridges it to the CPX to lit
+the neopixel ring. One interesting aspect of this setup, is that CPX runs a
+derivative version of micropython too and the host drives the CPX using its
+REPL. This way the host can technically talk to the full array of sensors and
+transducers without being artificially limited by APIs.
+
+Files in this directory
+=======================
+
+* ``cpx_driver.py`` - Implement REPL bridge, exposing the light sensor and the
+  neopixel ring drivers
+* ``cpx_transducer.py`` - ThingFlow thin layer on top of cpx_driver
+* ``server_cpx.py`` - ThingFlow CPX demo

--- a/example_code/cpx_demo/cpx_driver.py
+++ b/example_code/cpx_demo/cpx_driver.py
@@ -1,0 +1,166 @@
+'''Circuit Playground Express (CPX) REPL driver
+
+Run this module on a host computer with CPX plugged in a USB port::
+
+    import cpx_driver
+
+    cpx = cpx_driver.CPX()
+    cpx.light                                  # Get light sensor data
+    cpx.neopixel(rgb=(0, 10, 0))               # Turn all neopixels green
+    cpx.neopixel(buf=cpx_driver.vumeter(255))  # Turn neopixels as max vumeter
+'''
+
+# author:      Daniel Mizyrycki
+# license:     MIT
+# repository:  https://github.com/mzdaniel/micropython-iot
+
+import serial
+import itertools
+
+class Serial:
+    '''Drive serial communication'''
+
+    def __init__(self, dev_file):
+        self.prompt = '>>> '
+        self.serial = serial.Serial(dev_file, baudrate=115200, rtscts=True,
+            timeout=0.01)
+
+    def read(self):
+        data = self.serial.readall().decode()
+        if data[-len(self.prompt):] == self.prompt:
+            data = data[:-len(self.prompt)]
+        return data
+
+    def write(self, data):
+        self.serial.write((data + '\r\n').encode())
+        self.serial.flush()
+        self.serial.readline()
+
+    def flush(self):
+        self.serial.flush()
+        data = self.serial.readall().decode()
+        if data[-4:] != self.prompt:
+            pass  # handle condition if we didn't get prompt
+
+
+class CPX:
+    '''Circuit Playground Driver'''
+    pixel_count = 10
+    dev_file='/dev/ttyACM0'
+
+    def __init__(self, dev_file=dev_file):
+        ''' SerialException conditions:
+                Device or resource busy: '/dev/ttyACM0'
+                No such file or directory: '/dev/ttyACM0'
+        '''
+        self.serial = Serial(dev_file)
+        self.send_nores('')  # CPX require a new line to enter REPL
+        self.send_nores('import analogio, digitalio, board')
+        self.send_nores('light = analogio.AnalogIn(board.LIGHT)')
+        self.send_nores('from neopixel_write import neopixel_write')
+        self.send_nores('neopixel_pin = digitalio.DigitalInOut(board.NEOPIXEL)')
+        self.send_nores('neopixel_pin.direction = digitalio.Direction.OUTPUT')
+        self.send_nores('neopixel = lambda buf: neopixel_write(neopixel_pin, buf)')
+        self.neopixel_buf = bytearray(self.pixel_count * 3)  # 10 neopixels with 3 bytes per pixel
+
+    def send_nores(self, line):
+        self.serial.write(line)
+        self.serial.read()
+
+    def send_res(self, line):
+        self.serial.write(line)
+        return self.serial.read()
+
+    def send_res_int(self, line):
+        return int(self.send_res(line))
+
+    @property
+    def light(self):
+        '''Get Light sensor data'''
+        return self.send_res_int('light.value')
+
+    def neopixel(self, rgb=None, pix_nr=None, buf=None):
+        ''' Drive neopixel ring
+            if no pix_nr is given, use rgb on all pixels
+            use buf if no rgb or pix_nr are given'''
+        if buf:  # Prepare buf for CPX  (it uses grb)
+            buf = [i for i in buf]
+            buf = tuple(itertools.chain(*zip(buf[1::3], buf[0::3], buf[2::3])))
+        if not rgb and pix_nr is None and buf:
+            self.send_nores('neopixel(bytearray(%s))' % str(buf))
+            self.neopixel_buf = bytearray(buf)
+        elif rgb and pix_nr is None:
+            rgb = (rgb[1], rgb[0], rgb[2])
+            self.send_nores('neopixel(bytearray(%s*%s))' % (
+                str(rgb), self.pixel_count))
+            self.neopixel_buf = bytearray(rgb * self.pixel_count)
+        elif rgb and pix_nr is not None:
+            rgb = [rgb[1], rgb[0], rgb[2]]
+            buf = [i for i in self.neopixel_buf]
+            buf = buf[:pix_nr*3] + rgb + buf[(pix_nr+1)*3:]
+            self.send_nores('neopixel(bytearray(%s))' % str(buf))
+            self.neopixel_buf = bytearray(buf)
+
+
+def vumeter(level, pixel_count=CPX.pixel_count, bright_coef=0.05):
+    '''Return a vumeter neopixel buffer based on level 0-255
+       bright_coef is used to dim cpx bright neopixels'''
+
+    def clamp(n, min, max):
+        '''Return   n if min <= n <= max
+                  min if n < min
+                  max if n > max
+        '''
+        return sorted((min, n, max))[1]
+
+    def wheel(level):
+        '''Convert a linear level into rgb color tuple
+        >>> level_to_rgb(0)
+        (255, 0, 0)
+        >>> level_to_rgb(127)
+        (1, 254, 0)
+        >>> level_to_rgb(128)
+        (0, 255, 0)
+        >>> level_to_rgb(255)
+        (0, 1, 254)
+        >>> level_to_rgb(256)
+        (0, 0, 255)
+        '''
+        level = clamp(level, 0, 256)
+        if level < 128:
+            return (255-level*2, level*2, 0)
+        elif level < 256:
+            level -= 128
+            return (0, 255-level*2, level*2)
+        else:
+            return (0, 0, 255)
+
+    def level_to_rgb(level, brightness=1):
+        '''Transform level to rgb for strip sensor
+           0 <= level <= 255'''
+        brightness = clamp(brightness, 0, 1)
+        rgb = tuple(int(c*brightness*bright_coef) for c in wheel(level))
+        return rgb
+
+    def vumeter_brightness(level, pixel_count=pixel_count):
+        '''Transform level to a vumeter brightness
+        >>> brightness(0, 10)
+        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+        >>> brightness(1, 10)
+        [10, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+        >>> brightness(25, 10)
+        [250, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+        >>> brightness(26, 10)
+        [255, 5, 0, 0, 0, 0, 0, 0, 0, 0]
+        >>> brightness(255, 10)
+        [255, 255, 255, 255, 255, 255, 255, 255, 255, 255]
+        '''
+        coef = 255/pixel_count
+        return [0 if level < coef*i else
+            255 if coef*(i+1) <= level else
+            int(level%coef*10) for i in range(10)]
+
+    colors = [int(i*256/pixel_count) for i in range(pixel_count)]
+    buf = bytearray(sum((level_to_rgb(level=c, brightness=b/255)
+        for c, b in zip(colors, vumeter_brightness(level))), ()))
+    return buf

--- a/example_code/cpx_demo/cpx_transducer.py
+++ b/example_code/cpx_demo/cpx_transducer.py
@@ -1,0 +1,43 @@
+'''Implement CircuitPlayground Express (CPX) ThingFlow 
+   sensors and transducers'''
+
+from thingflow.base import InputThing, SensorAsOutputThing
+from cpx_driver import CPX, vumeter
+
+cpx = None
+
+def init_cpx(devname='/dev/tty.usbmodem1451'):
+    '''Initialize cpx. Use '/dev/ttyACM0' on linux'''
+    global cpx
+    cpx = CPX(devname)
+
+def check_cpx_initialized():
+    if not cpx:
+        raise Exception('CPX board was not initialized.\n'
+            'Call transducer.init_cpx function to initialize CPX board.')
+
+
+class LightSensor(SensorAsOutputThing):
+    '''Create a Circuit Playground LightSensor'''
+    def __init__(self, sensor_id='lux'):
+        check_cpx_initialized()
+        super().__init__(self)
+        self.sensor_id = sensor_id  # Required by SensorAsOutputThing
+    def sample(self):
+        return cpx.light
+
+
+class RingInputThing(InputThing):
+    def __init__(self, *args, **kwargs):
+        '''Ensure the underlying CPX has been initialized'''
+        check_cpx_initialized()
+        super().__init__()
+
+    def on_next(self, evt):
+        '''Display on neopixels the 0 <= level <= 255 transformation to a
+           pretty intensity colorwheel (ore pixels light-up varying in
+           intensity and turning from red to blue.
+        '''
+        level = evt.val
+        cpx.neopixel(buf=vumeter(level))
+

--- a/example_code/cpx_demo/server_cpx.py
+++ b/example_code/cpx_demo/server_cpx.py
@@ -1,0 +1,33 @@
+'''Drive a CircuitPlayground Express neopixel ring with wireless
+MQTTReader data from an analog to digital conversor.
+Run this program on the MQTT broker host with::
+
+    python server_cpx.py
+'''
+
+import asyncio
+import thingflow.filters.map   # adds map() method
+import thingflow.filters.json  # adds json() method
+from thingflow.base import Scheduler, SensorEvent
+from thingflow.adapters.mqtt import MQTTReader
+from cpx_transducer import RingInputThing, init_cpx
+
+def setup_flow(topic):
+    mqtt = MQTTReader('localhost', topics=[(topic, 0),])
+    ring = RingInputThing()
+    decoded = (mqtt
+        .map(lambda m:(m.payload).decode('utf-8'))
+        .from_json(constructor=SensorEvent)
+        .map(lambda evt: SensorEvent(sensor_id=evt.sensor_id,
+            ts=evt.ts, val=int(evt.val * 255))))
+    decoded.output()
+    decoded.connect(ring)
+    return mqtt
+
+
+init_cpx()
+mqtt = setup_flow('sensor-data')
+
+scheduler = Scheduler(asyncio.get_event_loop())
+scheduler.schedule_on_private_event_loop(mqtt)
+scheduler.run_forever()


### PR DESCRIPTION
This PR adds the software and drivers needed to shows how to drive a  neopixel ring of a CPX using data from a ESP8266. The data is generated from an analog-to-digital convertor on the ESP8266 taking the analog signal from a potentiometer and transmited wirelessly using a ThingFlow MQTTWriter. Then the host computer decodes the wireless ThingFlow MQTTReader data and bridges it to the CPX to lit the neopixel ring.